### PR TITLE
Fix for SSL Error: certificate verify failed

### DIFF
--- a/app/models/spree/gateway/pay_pal_express.rb
+++ b/app/models/spree/gateway/pay_pal_express.rb
@@ -22,7 +22,10 @@ module Spree
         :mode      => preferred_server.present? ? preferred_server : "sandbox",
         :username  => preferred_login,
         :password  => preferred_password,
-        :signature => preferred_signature)
+        :signature => preferred_signature),
+        :ssl_options => {
+          ca_file: nil
+        }
       provider_class.new
     end
 


### PR DESCRIPTION
As of Sept 2020 PayPal has stopped accepting requests made to their API with a certificate that was once bundled in the `paypal-ruby-sdk` gem used as a dependency to this package.

This issue causes all paypal payments to be rejected due to an SSL handshake error.

The solution, as suggested on StackOverflow is to force the underlying paypal-ruby-sdk gem to ignore the certificate bundled in the codebase and instead rely on the API.

Reference: https://stackoverflow.com/questions/63221087/opensslsslsslerror-ssl-connect-returned-1-errno-0-state-error-certificate/63305975\#63305975

PayPal's official article: https://www.paypal.com/va/smarthelp/article/discontinue-use-of-verisign-g5-root-certificates-ts2240